### PR TITLE
show message if mHBS Tracker is not installed

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -436,16 +436,23 @@ $$(document).on('click', ".pb-standalone-video", function () {
 */
 $$(document).on('click', ".mHBSTracker", function () {
   var sApp = startApp.set({
-    "component": ["com.dhis2.debug", "org.dhis2.usescases.splash.SplashActivity"],
+    "component": ["edu.iupui.soic.bhi.plhi.mhbs.trackercapture", "org.hisp.dhis.android.sdk.ui.activities.SplashActivity"],
     "flags": ["FLAG_ACTIVITY_NEW_TASK"]
   }).start( function() {
       console.log("mHBS Tracker App Started.");
     }, function(error) {
-      alert("Install mHBS Tracker Application!");
+      var sApp = startApp.set({
+        "component": ["com.dhis2.debug", "org.dhis2.usescases.splash.SplashActivity"],
+        "flags": ["FLAG_ACTIVITY_NEW_TASK"]
+      }).start( function() {
+          console.log("mHBS Tracker App Started.");
+        }, function(error) {
+          alert("Install mHBS Tracker Application!!!");
+        }
+      );
     }
   );
 });
-//TODO : change the package name based on debug or release flavour of the application
 
 /* basically while we are downloading shows the preloader
  */

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -436,10 +436,16 @@ $$(document).on('click', ".pb-standalone-video", function () {
 */
 $$(document).on('click', ".mHBSTracker", function () {
   var sApp = startApp.set({
-    "component": ["edu.iupui.soic.bhi.plhi.mhbs.trackercapture", "org.hisp.dhis.android.sdk.ui.activities.SplashActivity"],
+    "component": ["com.dhis2.debug", "org.dhis2.usescases.splash.SplashActivity"],
     "flags": ["FLAG_ACTIVITY_NEW_TASK"]
-  }).start();
+  }).start( function() {
+      console.log("mHBS Tracker App Started.");
+    }, function(error) {
+      alert("Install mHBS Tracker Application!");
+    }
+  );
 });
+//TODO : change the package name based on debug or release flavour of the application
 
 /* basically while we are downloading shows the preloader
  */


### PR DESCRIPTION
Fixes #192 

**Summary**
On click of "mHBS Tracker" option in side navigation bar, it opens the Tracker app if installed.
Otherwise, it displays a message to install the app.

**VIdeo Snippet**
![libre_install](https://user-images.githubusercontent.com/31249460/76362878-e55b1180-6347-11ea-96d6-f102e1122357.gif)

**Note**
The package name is of the Tracker application is mentioned as "com.dhis2.debug" for debug apk, which has to be changed to "com.dhis2" for release apk.